### PR TITLE
Refactor code to pass references instead of values for input vectors …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea/

--- a/src/curfit.rs
+++ b/src/curfit.rs
@@ -3,8 +3,8 @@ use crate::fpcurf::fpcurf;
 
 pub fn curfit(
     iopt: i8,
-    x: Vec<f64>,
-    y: Vec<f64>,
+    x: &Vec<f64>,
+    y: &Vec<f64>,
     w: Vec<f64>,
     xb: f64,
     xe: f64,

--- a/src/curfit.rs
+++ b/src/curfit.rs
@@ -3,19 +3,19 @@ use crate::fpcurf::fpcurf;
 
 pub fn curfit(
     iopt: i8,
-    x: &Vec<f64>,
-    y: &Vec<f64>,
-    w: Vec<f64>,
+    x: &[f64],
+    y: &[f64],
+    w: &[f64],
     xb: f64,
     xe: f64,
     k: usize,
     s: f64,
     nest: usize,
-    t: Vec<f64>,
-    wrk: Vec<f64>,
+    t: &[f64],
+    wrk: &[f64],
 ) -> (Vec<f64>, usize, Vec<f64>, f64, i8) {
     let m: usize = x.len();
-    let mut t: Vec<f64> = t;
+    let mut t: Vec<f64> = t.to_vec();
     let n: usize = nest.clone();
     let lwrk: usize = wrk.len();
     assert!(k <= 5, "the degree k must be within 1 and 5");

--- a/src/fpbspl.rs
+++ b/src/fpbspl.rs
@@ -7,7 +7,7 @@
 ///      Thus it is imperative that that k <= l <= n-k but this
 ///      is not checked.
 ///  The original subroutine in FITPACK by Paul Dierckx is named fpbspl
-pub fn fpbspl(x: f64, t: &Vec<f64>, k: usize, l: usize) -> Vec<f64> {
+pub fn fpbspl(x: f64, t: &[f64], k: usize, l: usize) -> Vec<f64> {
     let mut h: [f64; 20] = [0.0; 20];
     let mut hh: [f64; 19] = [0.0; 19];
     h[0] = 1.0;

--- a/src/fpchec.rs
+++ b/src/fpchec.rs
@@ -14,7 +14,7 @@
 ///             t[j] < y[j] < t[j+k+1], j=0,1,2,...,n-k-1
 ///
 ///  The original subroutine in FITPACK by Paul Dierckx is named fpchec
-pub(crate) fn check_knots(x: &Vec<f64>, t: &Vec<f64>, k: usize, m: usize, n: usize) -> u8 {
+pub(crate) fn check_knots(x: &[f64], t: &[f64], k: usize, m: usize, n: usize) -> u8 {
     let k1: usize = k + 1;
     let k2: usize = k1 + 1;
     let nk1: usize = n - k1;

--- a/src/fpcurf.rs
+++ b/src/fpcurf.rs
@@ -5,8 +5,8 @@ use std::cmp::{max, min};
 
 pub fn fpcurf(
     iopt: i8,
-    x: Vec<f64>,
-    y: Vec<f64>,
+    x: &Vec<f64>,
+    y: &Vec<f64>,
     w: Vec<f64>,
     m: usize,
     xb: f64,

--- a/src/fpcurf.rs
+++ b/src/fpcurf.rs
@@ -5,9 +5,9 @@ use std::cmp::{max, min};
 
 pub fn fpcurf(
     iopt: i8,
-    x: &Vec<f64>,
-    y: &Vec<f64>,
-    w: Vec<f64>,
+    x: &[f64],
+    y: &[f64],
+    w: &[f64],
     m: usize,
     xb: f64,
     xe: f64,
@@ -353,11 +353,11 @@ pub fn fpcurf(
                     break 'outer;
                 }
                 assert_ne!(
-                iter, maxit,
-                "Error. The maximal number of iterations maxit (set to 20 by the program) allowed
+                    iter, maxit,
+                    "Error. The maximal number of iterations maxit (set to 20 by the program) allowed
                  for finding a smoothing spline with fp=s has been reached.
                  Probably cause: s is too small."
-            );
+                );
                 // carry out one more step of the iteration process
                 p2 = p;
                 f2 = fpms;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod fprota;
 /// let x = vec![0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 /// let y = vec![0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0];
 ///
-/// let (t, c, k) = splrep(x, y, None, None, None, None, None, None, None, None, None, None);
+/// let (t, c, k) = splrep(&x, &y, None, None, None, None, None, None, None, None, None, None);
 /// ```
 ///
 /// #### Parameters
@@ -80,8 +80,8 @@ mod fprota;
 ///
 
 pub fn splrep(
-    x: Vec<f64>,
-    y: Vec<f64>,
+    x: &Vec<f64>,
+    y: &Vec<f64>,
     w: Option<Vec<f64>>,
     xb: Option<f64>,
     xe: Option<f64>,
@@ -143,7 +143,7 @@ pub fn splrep(
     let wrk: Vec<f64> = vec![0.0; m * (k + 1) + nest * (7 + 3 * k)];
 
     let (t, n, c, _fp, _ier): (Vec<f64>, usize, Vec<f64>, f64, i8) =
-        curfit::curfit(task, x, y, w, xb, xe, k, s, nest, t, wrk);
+        curfit::curfit(task, &x, &y, w, xb, xe, k, s, nest, t, wrk);
 
     let tck = (t[..n].to_vec(), c[..n].to_vec(), k);
     return tck;
@@ -159,7 +159,7 @@ pub fn splrep(
 /// let x = vec![0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 /// let y = vec![0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0];
 ///
-/// let (t, c, k) = splrep(x, y, None, None, None, None, None, None, None, None, None, None);
+/// let (t, c, k) = splrep(&x, &y, None, None, None, None, None, None, None, None, None, None);
 ///
 /// // the points where we want to evaluate the spline
 /// let x_evaluate: Vec<f64> = vec![1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0];
@@ -249,7 +249,7 @@ pub fn splev(t: Vec<f64>, c: Vec<f64>, k: usize, x: Vec<f64>, e: usize) -> Vec<f
 /// let x = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 /// let y = vec![0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0];
 ///
-/// let (t, c, k) = splrep(x, y, None, None, None, None, None, None, None, None, None, None);
+/// let (t, c, k) = splrep(&x, &y, None, None, None, None, None, None, None, None, None, None);
 ///
 /// // the points where we want to evaluate the spline
 /// let x_evaluate: Vec<f64> = vec![1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0];
@@ -321,7 +321,7 @@ pub fn splev_uniform(t: &Vec<f64>, c: &Vec<f64>, k: usize, x: f64) -> f64 {
 /// let x = vec![0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 /// let y = vec![0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0];
 ///
-/// let (t, c, k) = splrep(x, y, None, None, None, None, None, None, None, None, None, None);
+/// let (t, c, k) = splrep(&x, &y, None, None, None, None, None, None, None, None, None, None);
 ///
 /// // the points where we want to evaluate the spline
 /// let x_evaluate: Vec<f64> = vec![1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0];
@@ -452,7 +452,7 @@ pub fn splder(t: &Vec<f64>, c: &Vec<f64>, k: usize, x: &Vec<f64>, nu: usize) -> 
 /// let x = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 /// let y = vec![0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0];
 ///
-/// let (t, c, k) = splrep(x, y, None, None, None, None, None, None, None, None, None, None);
+/// let (t, c, k) = splrep(&x, &y, None, None, None, None, None, None, None, None, None, None);
 ///
 /// // the points where we want to evaluate the spline
 /// let x_evaluate: Vec<f64> = vec![1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0];
@@ -596,7 +596,7 @@ mod tests {
             0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0,
         ];
         let (t, c, k) = splrep(
-            x, y, None, None, None, None, None, None, None, None, None, None,
+            &x, &y, None, None, None, None, None, None, None, None, None, None,
         );
         let t_ref: Vec<f64> = vec![
             0.5, 0.5, 0.5, 0.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 11.0, 11.0, 11.0, 11.0,
@@ -644,8 +644,8 @@ mod tests {
             0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0,
         ];
         let (t, c, k) = splrep(
-            x,
-            y,
+            &x,
+            &y,
             None,
             None,
             None,
@@ -696,8 +696,8 @@ mod tests {
         ];
         let w: Vec<f64> = vec![0.5, 1.0, 2.0, 1.0, 2.0, 3.0, 1.0, 0.1, 8.0, 0.2, 3.0, 2.0];
         let (t, c, k) = splrep(
-            x,
-            y,
+            &x,
+            &y,
             Some(w),
             None,
             None,
@@ -758,8 +758,8 @@ mod tests {
         ];
         let w: Vec<f64> = vec![0.5, 1.0, 2.0, 1.0, 2.0, 3.0, 1.0, 0.1, 8.0, 0.2, 3.0, 2.0];
         let (t, c, k) = splrep(
-            x,
-            y,
+            &x,
+            &y,
             Some(w),
             None,
             None,
@@ -810,8 +810,8 @@ mod tests {
         ];
         let t: Vec<f64> = vec![2.5, 3.5, 4.5];
         let (t, c, k) = splrep(
-            x,
-            y,
+            &x,
+            &y,
             None,
             None,
             None,
@@ -867,8 +867,8 @@ mod tests {
         let w: Vec<f64> = vec![0.5, 1.0, 2.0, 1.0, 2.0, 3.0, 1.0, 0.1, 8.0, 0.2, 3.0, 2.0];
         let t: Vec<f64> = vec![2.5, 3.5, 4.5];
         let (t, c, k) = splrep(
-            x,
-            y,
+            &x,
+            &y,
             Some(w),
             Some(0.0),
             Some(16.0),
@@ -920,8 +920,8 @@ mod tests {
             0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0,
         ];
         let (t, c, k) = splrep(
-            x,
-            y,
+            &x,
+            &y,
             None,
             None,
             None,
@@ -977,7 +977,7 @@ mod tests {
             0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0,
         ];
         let (t, c, k) = splrep(
-            x, y, None, None, None, None, None, None, None, None, None, None,
+            &x, &y, None, None, None, None, None, None, None, None, None, None,
         );
         let x_ev: Vec<f64> = vec![1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0];
         let y_ev: Vec<f64> = splev(t, c, k, x_ev, 0);
@@ -1001,8 +1001,8 @@ mod tests {
             0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0,
         ];
         let (t, c, k) = splrep(
-            x,
-            y,
+            &x,
+            &y,
             None,
             None,
             None,
@@ -1035,7 +1035,7 @@ mod tests {
             1.0, 4.0, 7.0, 18.0, 22.0, 41.0, 45.0, 63.0, 80.0, 99.0, 119.0,
         ];
         let (t, c, k) = splrep(
-            x, y, None, None, None, None, None, None, None, None, None, None,
+            &x, &y, None, None, None, None, None, None, None, None, None, None,
         );
 
         let x_ev: Vec<f64> = vec![1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 7.5, 10.5, 10.9, 11.0];


### PR DESCRIPTION
…in `splrep` and related functions. Fixes #1234.